### PR TITLE
Fixed assumptions about return values

### DIFF
--- a/traversable_menu.js
+++ b/traversable_menu.js
@@ -555,7 +555,13 @@ TraversableMenu.prototype.elementFind = function( selector ) {
 
   try {
     var container = this.panelsGetContainer();
-    return container.querySelector( selector );
+
+    if ( container ) {
+      return container.querySelector( selector );
+    }
+
+    return null;
+    
   }
   catch(e) {
     throw e;

--- a/traversable_menu.js
+++ b/traversable_menu.js
@@ -218,13 +218,13 @@ TraversableMenu.prototype.panelInitialize = function( panel, depth, options ) {
     //
     var menu_items = this.childMenuItemsGet(panel);
 
-    for ( var i = 0; i < menu_items.length; i++ ) {      
+    for ( var i = 0; i < menu_items.length; i++ ) {
 
       //
-      // Keep a rolling count of all the menu items all the way down the panels, so we can create unique IDs      
+      // Keep a rolling count of all the menu items all the way down the panels, so we can create unique IDs
       //
-      this.menu_item_index ++; 
-    
+      this.menu_item_index ++;
+
       this.menuItemInit(menu_items[i]);
 
       child_panel = this.childPanelGet(menu_items[i]);
@@ -241,14 +241,14 @@ TraversableMenu.prototype.panelInitialize = function( panel, depth, options ) {
         //
         // Initialize child triggers
         //
-        this.childTriggerInit(menu_items[i], panel);        
+        this.childTriggerInit(menu_items[i], panel);
 
       }
 
 
 
     }
-   
+
 
   }
   catch(e) {
@@ -679,7 +679,7 @@ TraversableMenu.prototype.panelIDSetByDepthIndex = function( panel, depth, index
 
   try {
 
-    var id_suffix = 'panel_' + depth.toString() + '_' + index.toString(); 
+    var id_suffix = 'panel_' + depth.toString() + '_' + index.toString();
 
     //panel.setAttribute( 'data-panel-id', id_suffix );
     panel.setAttribute( 'id', this.elementIDPrefix() + '_' + id_suffix );
@@ -847,9 +847,13 @@ TraversableMenu.prototype.panelsHeightStore = function() {
   var panels = this.panelsGetAll();
   var height = 0;
 
-  for ( var i = 0; i < panels.length; i++ ) {
-    height = TraversableMenu.heightCalculateBasedOnImmediateChildren(panels[i]);
-    panels[i].setAttribute('data-panel-height', height);
+  if (panels !== null) {
+
+    for ( var i = 0; i < panels.length; i++ ) {
+      height = TraversableMenu.heightCalculateBasedOnImmediateChildren(panels[i]);
+      panels[i].setAttribute('data-panel-height', height);
+    }
+
   }
 
 }


### PR DESCRIPTION
`TraversableMenu.prototype.elementFind` assumed `TraversableMenu.prototype.panelsGetContainer` returned an object, but `null` is also possible.  The check from `TraversableMenu.prototype.elementFindAll` was added to the function body.

Similarly, `TraversableMenu.prototype.panelsHeightStore` assumed `TraversableMenu.prototype.panelsGetAll` returns only non-null, but `null` is a possible value, so a check was added for that.

CS Fixer also removed some trailing whitespace.