### PR TITLE
Added support for trigger elements to have nested elements

### DIFF
--- a/traversable_menu.js
+++ b/traversable_menu.js
@@ -2076,6 +2076,18 @@ TraversableMenu.panelTriggerEventHandler = function( traversable_menu_obj, event
     var trigger = event.target;
     var last_event = null;
     var panel_id = trigger.getAttribute('data-panel-trigger-for');
+    if ( !panel_id ) {
+      traversable_menu_obj.debug('Could not determine panel_id in panelTriggerEventHandler. Searching parent elements for data-panel-trigger-for within the panel or menu item.');
+      var parent_selector_stop_panel = traversable_menu_obj.option('selectors.panel');
+      var parent_selector_stop_menu_item = traversable_menu_obj.option('selectors.menu_item');
+      var parent_selector_match = '[data-panel-trigger-for]';
+      var parent_selector_string = parent_selector_match + ', ' + parent_selector_stop_panel + ', ' + parent_selector_stop_menu_item;
+      //
+      // Look for element matching selector without going past elements matching "stop" selectors.
+      //
+      trigger = TraversableMenu.nearestAncestor(trigger, parent_selector_string);
+      panel_id = trigger.getAttribute('data-panel-trigger-for');
+    }
 
     if ( panel_id == null ) {
       traversable_menu_obj.debug('Could not determine panel_id in panelTriggerEventHandler. Tried to read data-panel-trigger-for argument and got null. This might not be a problem if you are lazy loading panel data');


### PR DESCRIPTION
Only the `event.target` was being checked for the right data attribute (`data-panel-trigger-for`). Triggers having nested elements is a fairly common use-case, so the `event.target` parent elements should also be checked for the relevant data attribute.

We don't want to check every parent element because if the event is occurring in a nested menu it will incorrectly find the matching data attribute of a parent panel/menu. I identified the 2 places these links appear in the mark up: within the `panel`, and within the `menu_item`. When searching for the data attribute on parent elements, I used these 2 selectors as stopping points to prevent false positives.